### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # A Genomics Adventure
-This tutorial is based on a workshop that was written many years ago by Konrad Paszkiewicz, whilst he was the head of Exeter University's Sequencing Service. Over the years it has been extensivley updated and modified by several colleages (listed below), taught at Exeter Universtity, and also at the [evomics.org](https://evomics.org/) Workshop on Genomics since 2014. It has now been reproduced here, in a slightly new form - again with many updates.
+This tutorial is based on a workshop that was written many years ago by Konrad Paszkiewicz, whilst he was the head of Exeter University's Sequencing Service. Over the years it has been extensively updated and modified by several colleagues (listed below), taught at Exeter University, and also at the [evomics.org](https://evomics.org/) Workshop on Genomics since 2014. It has now been reproduced here, in a slightly new form - again with many updates.
 
 Many thanks to:
  * [Konrad Paszkiewicz](https://scholar.google.com/citations?user=yrHDETIAAAAJ&hl=en), CTO Hummingbird Biosciences.

--- a/chapter_2/task_15.md
+++ b/chapter_2/task_15.md
@@ -8,7 +8,7 @@ bedtools coverage \
 -b ecoli_mapped_namesort_fixmate_sort_markdup.bam > gene_coverage.txt
 ```
 
-Oh no! :scream: What happenend? Did you get a message that says "Killed"? It's okay, Don't Panic! When you see a message similar to this it usually means that there isn't enough RAM available for this task - and so the Operating System has 'killed' :skull: the operation (sounds extreme I know) so that you can continue to use it. Limitations like these may well happen throughout your continued bioinformatics adventures here and in real life :TM:! :weary: You will learn, with time, to navigate around them and/or you can go and do some mindfullness techniques - and develop an unhealthy addiction to :coffee:! Anyway, :relaxed: you can do it! :muscle:
+Oh no! :scream: What happened? Did you get a message that says "Killed"? It's okay, Don't Panic! When you see a message similar to this it usually means that there isn't enough RAM available for this task - and so the Operating System has 'killed' :skull: the operation (sounds extreme I know) so that you can continue to use it. Limitations like these may well happen throughout your continued bioinformatics adventures here and in real life :TM:! :weary: You will learn, with time, to navigate around them and/or you can go and do some mindfulness techniques - and develop an unhealthy addiction to :coffee:! Anyway, :relaxed: you can do it! :muscle:
 
 NB - You might have not got that error and wonder what I am on about, but trust me at some point something similar will happen, so it is useful to follow the logic below to try and understand you data as best as possible with the resources you currently have.
 

--- a/chapter_2/task_2.md
+++ b/chapter_2/task_2.md
@@ -20,7 +20,7 @@ PS - There are also programs for removing or demultiplexing special barcode data
 
 PPS - Long reads require a whole suite of different programs - especially Oxford Nanopore - due to the different technologies and errors involved in base calling.
 
-:warning: - Don't run these commmands now. You can try them if you like after you have completed this chapter ⚠️
+:warning: - Don't run these commands now. You can try them if you like after you have completed this chapter ⚠️
  
 ```bash
 conda install -c bioconda fastp

--- a/chapter_3/task_1.md
+++ b/chapter_3/task_1.md
@@ -1,10 +1,10 @@
 # Chapter 3 - Assembly of Unmapped Reads
-In this chapter of our adventure we will continue the analysis of a strain of ​*E. coli*.​ In the previous chapter we cleaned our data, checked QC metrics, mapped our data to a reference, obtained a list of variants and identyfied an overview of any missing regions.
+In this chapter of our adventure we will continue the analysis of a strain of ​*E. coli*.​ In the previous chapter we cleaned our data, checked QC metrics, mapped our data to a reference, obtained a list of variants and identified an overview of any missing regions.
 
 Now, we will examine those reads which did not map to the reference genome. We want to know what these sequences represent. Are they novel genes, plasmids or just contamination? To do this we will extract the unmapped reads, evaluate their quality, prepare them for de-novo assembly, assemble them using SPAdes, generate assembly statistics and then produce some annotation via Pfam, BLAST and RAST. :cold_sweat:
 
 ## Task 1 - Extract the Unmapped Reads
-Let's make sure we are in the right place to start out adventure and refresh our memories of what is in this directory.
+Let's make sure we are in the right place to start our adventure and refresh our memories of what is in this directory.
 ```bash
 cd ~/workshop_materials/genomics_adventure/sequencing_data/ecoli
 
@@ -25,7 +25,7 @@ samtools view ../mapping_to_reference/ecoli_mapped_namesort_fixmate_sort_markdup
 
 You should see a bunch a of text, numbers and sequence data on your screen. Don't panic, this is just how the SAM format looks. It is arranged in columns separated by a tab, and each row is one read. At this time we are only really interested in the second column (the flag), you can look up the meaning for the rest [here](https://en.wikipedia.org/wiki/SAM_(file_format)#Format):mag:.
 
-You should see a number like "2147" on the first row. On its own this number doesn't tell us too much, but we can use a tool to look up what it means [here](https://broadinstitute.github.io/picard/explain-flags.html). You can see that the tool tells us that this read is mapped, and that its read-mate is also mapped. It also tells us that it is mapped to the reverse strand, is the first read of the pair to be mapped, and that it is a supplementary alignment. So, ths is not a read we are looking for right now!
+You should see a number like "2147" on the first row. On its own this number doesn't tell us too much, but we can use a tool to look up what it means [here](https://broadinstitute.github.io/picard/explain-flags.html). You can see that the tool tells us that this read is mapped, and that its read-mate is also mapped. It also tells us that it is mapped to the reverse strand, is the first read of the pair to be mapped, and that it is a supplementary alignment. So, this is not a read we are looking for right now!
 
 Now, using the "Decoding SAM flags" tool, can you figure out what flag number we need for reads that are unmapped and where their mates are also unmapped? Click below to reveal the answer.
 
@@ -40,7 +40,7 @@ Now, using the "Decoding SAM flags" tool, can you figure out what flag number we
   But why 12 and not 13 or some other combination? Remember we wanted "read unmapped" (4) AND "mate unmapped" (8), so selecting both gives us "12" (or 0000001100 in binary), that's all we need. Nonetheless, some of you may have also decided to include either "read paired" (1) or "read mapped in proper pair" (2) increasing the value. Well, the latter is not useful as we are looking for unmapped reads only. Secondly, even though "read paired" is what we are looking for it is not often a flag that is used on its own when reads are unmapped - you weren't to know. But, you can also think of what 13 represents as a subset of 12, and as we want to get all the reads we should use the lower number! :ok_woman:    
 </details>
 
-Now that we have identified the corect bit flag, we can go ahead with filtering of the BAM file from Chapter 2, here using samtools.
+Now that we have identified the correct bit flag, we can go ahead with filtering of the BAM file from Chapter 2, here using samtools.
 ```bash
 samtools view -b -f 12 ../sequencing_data/ecoli/mapping_to_reference/ecoli_mapped_namesort_fixmate_sort_markdup.bam -o unmapped.bam
 ```

--- a/tests/test_chapter_3.sh
+++ b/tests/test_chapter_3.sh
@@ -1,5 +1,5 @@
 # task 1
-cd ~/workhsop_materials/genomics_adventure/sequencing_data/ecoli
+cd ~/workshop_materials/genomics_adventure/sequencing_data/ecoli
 ls -lath
 mkdir unmapped_assembly && cd unmapped_assembly
 samtools view ../sequencing_data/ecoli/mapping_to_reference/ecoli_mapped_namesort_fixmate_sort_markdup.bam | head -n 5


### PR DESCRIPTION
## Summary
- fix several spelling mistakes across docs
- correct path typo in chapter 3 test script

## Testing
- `bash tests/test_chapter_2.sh` *(fails: missing dependencies)*
- `bash tests/test_chapter_3.sh` *(fails: missing dependencies)*
- `bash tests/test_chapter_4.sh` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846eab2c29c8321872a3242ff4d3f3f