### PR TITLE
Add fastp paragraph with example

### DIFF
--- a/chapter_2/task_2.md
+++ b/chapter_2/task_2.md
@@ -5,6 +5,14 @@ Note: Typically when submitting Illumina data to NCBI or EBI you would submit th
 
 We are going to use the program '[Trim Galore!](https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/)' :mag: to adaptor trim and QC our data. There are many other programs that can do this, see below for examples, but this one is our current favourite - because it is actually a script that 'wraps' two programs together: '[cutadapt](https://cutadapt.readthedocs.io/en/stable/)' :mag: and '[fastqc](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)' :mag:.
 
+Another handy option is [fastp](https://github.com/OpenGene/fastp), which performs adaptor trimming, quality filtering and report generation all in a single step. It can serve as an all‑in‑one alternative to running separate tools. A typical command for processing paired-end reads is shown below:
+```bash
+fastp -i read_1.fastq.gz -I read_2.fastq.gz \
+      -o read_1_trimmed.fq.gz -O read_2_trimmed.fq.gz \
+      -h fastp.html -j fastp.json -w 4
+```
+
+
 ## Other QC Programs
 A list (by no means exhaustive) of some of the other most common adaptor trimming and QC programs:
 


### PR DESCRIPTION
## Summary
- add a short note about using `fastp` as a single-step alternative after introducing Trim Galore!
- show a typical paired-end fastp command

## Testing
- `bash tests/test_chapter_2.sh` *(fails: fastqc, trim_galore, seqtk, bwa, samtools, etc. not found)*
- `bash tests/test_chapter_3.sh` *(fails: samtools, bedtools, spades.py, etc. not found)*
- `bash tests/test_chapter_4.sh` *(fails: spades.py, quast.py, bwa, samtools, etc. not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495da16c2c83218385e2917f3b58c4