### PR TITLE
Fix pfam directory path in chapter 3 test

### DIFF
--- a/tests/test_chapter_3.sh
+++ b/tests/test_chapter_3.sh
@@ -53,7 +53,7 @@ blastn -subject ../../reference_sequences/ecoli/GCF_000005845.2_ASM584v2_genomic
 # task 7
 hmmpress ../../db/pfam/Pfam-A.hmm
 pfam_scan.pl -fasta contigs.orf.fasta \
--dir ~/workshop_materials/genomics_tutorial/db/pfam/ \
+-dir ~/workshop_materials/genomics_adventure/db/pfam/ \
 -outfile contigs.orf.pfam \
 -cpu 4 \
 -as


### PR DESCRIPTION
## Summary
- update the pfam database path in `tests/test_chapter_3.sh`

## Testing
- `bash tests/test_chapter_3.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495fc19834832188fff3bc73cf25f5