### PR TITLE
Update SPAdes reference

### DIFF
--- a/chapter_3/task_3.md
+++ b/chapter_3/task_3.md
@@ -17,7 +17,7 @@ spades.py --careful -o spades_assembly -1 unmapped_r1.fastq -2 unmapped_r2.fastq
 
 We are running the SPAdes assembly pipeline and specifying the "--careful" option to run a mismatch correction algorithm to reduce the number of errors; put the output in the "-o spades_assembly" directory and the read libraries (-2 and -2) to assemble. Just because SPAdes does a lot for you does not mean you should not try to understand the process...
 
-A pretty old overview of how SPAdes differs from 'velvet', a very old assembly program, can be found [here](http://thegenomefactory.blogspot.co.uk/2013/08/how-spades-differs-from-velvet.html). Nonetheless, it outlines the overall process quite nicely:
+A detailed description of the SPAdes workflow and its advantages can be found in the [SPAdes manual](https://cab.spbu.ru/files/release3.15.5/manual.html). It outlines the process quite nicely:
 
 1. Read error correction based on k-mer frequencies using ​BayesHammer.
 2. De Bruijn graph assembly at ​multiple ​k-mer sizes, not just a single fixed one.


### PR DESCRIPTION
## Summary
- update SPAdes reference to point to the official manual

## Testing
- `bash tests/test_chapter_3.sh` *(fails: samtools, bedtools, spades, and other tools not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495ff0004c8321833ff76f18c11605