### PR TITLE
Fix command to index contigs

### DIFF
--- a/chapter_4/task_3.md
+++ b/chapter_4/task_3.md
@@ -14,7 +14,7 @@ ln -s ../assembly/contigs.fasta .
 We now need to index and map our files, this is similar to the steps from Chapter 2... Indeed we will use the QC reads we created in Task 2! We will go through the steps one-by-one, although don't forget you can combine them all in to one step if you are feeling brave!
 ```bash
 # Index the contigs
-bwa index contig.fasta
+bwa index contigs.fasta
 
 # align QC reads to contigs and output SAM file
 bwa mem -t 2 contigs.fasta \


### PR DESCRIPTION
## Summary
- fix the `bwa index` command in Task 3 instructions

## Testing
- `bash tests/test_chapter_4.sh` *(fails: spades, quast, bwa, samtools, qualimap, blastn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498ed0490883219d32cead3739e1eb