### PR TITLE
Fix command in task 3 mapping snippet

### DIFF
--- a/chapter_4/task_3.md
+++ b/chapter_4/task_3.md
@@ -46,7 +46,7 @@ samtools index contigs_mapped_sorted.bam
   ../../sequencing_data/ecoli/read_1_val_1.fq.gz \
   ../../sequencing_data/ecoli/read_2_val_2.fq.gz \
   | samtools sort -O bam -o contigs_mapped_sorted.bam && \
-  bwa index contigs_mapped_sorted.bam
+  samtools index contigs_mapped_sorted.bam
   ```
 </details>
 

--- a/tests/test_chapter_4.sh
+++ b/tests/test_chapter_4.sh
@@ -20,7 +20,7 @@ bwa mem -t 2 contigs.fasta \
 samtools view -bS contigs_mapped.sam > contigs_mapped.bam
 samtools sort -o contigs_mapped_sorted.bam contigs_mapped.bam
 samtools index contigs_mapped_sorted.bam
-bash bwa index contigs.fasta && \ bwa mem -t 2 contigs.fasta \ ../../sequencing_data/ecoli/read_1_val_1.fq.gz \ ../../sequencing_data/ecoli/read_2_val_2.fq.gz \ | samtools sort -O bam -o contigs_mapped_sorted.bam && \ bwa index contigs_mapped_sorted.bam
+bwa index contigs.fasta && \ bwa mem -t 2 contigs.fasta \ ../../sequencing_data/ecoli/read_1_val_1.fq.gz \ ../../sequencing_data/ecoli/read_2_val_2.fq.gz \ | samtools sort -O bam -o contigs_mapped_sorted.bam && \ samtools index contigs_mapped_sorted.bam
 samtools flagstat contigs_mapped_sorted.bam
 qualimap bamqc -outdir bamqc -bam contigs_mapped_sorted.bam
 blastn -subject contigs.fasta \


### PR DESCRIPTION
## Summary
- correct final command in advanced mapping snippet
- update test script to remove `bash` prefix and use the correct command

## Testing
- `bash tests/test_chapter_4.sh` *(fails: `spades.py` not found and others)*

------
https://chatgpt.com/codex/tasks/task_e_68498f0331c48321a43163b61ef08241