### PR TITLE
Fix typos across chapter 5 docs

### DIFF
--- a/chapter_5/task_3.md
+++ b/chapter_5/task_3.md
@@ -7,7 +7,7 @@ trim_galore --paired --fastqc --gzip --cores 4 --length 100 \
 SRR491287_1.fastq.gz SRR491287_2.fastq.gz
 ```
 
-You can check the number of filtered reads using "grep –c" and the quality of trimmed reads with fastqc if you want.
+You can check the number of filtered reads using "grep -c" and the quality of trimmed reads with fastqc if you want.
 
 For our next trick we want to keep the long reads from PacBio even though they are of lower quality. We are relying
 on the assembler to use them appropriately...

--- a/chapter_5/task_4.md
+++ b/chapter_5/task_4.md
@@ -32,7 +32,7 @@ quast.py --output-dir quast contigs.fasta
 cat quast/report.txt
 ```
 
-If you ran the assembly command - outside of the workhop - you may get slightly different results here, as SPAdes uses a random seed.
+If you ran the assembly command - outside of the workshop - you may get slightly different results here, as SPAdes uses a random seed.
 ```
 Assembly                    contigs
 # contigs (>= 0 bp)         612    

--- a/chapter_5/task_5.md
+++ b/chapter_5/task_5.md
@@ -1,5 +1,5 @@
 # Create a Hybrid Assembly
-Now will execute the same command, but this time include the longer PacBio reads to see the effect it has on our assembly.
+Now we will execute the same command, but this time include the longer PacBio reads to see the effect it has on our assembly.
 
 Return to the pseudomonas directory:
 ```bash
@@ -8,7 +8,7 @@ cd /home/zoo/zool2474/genomics_adventure/pseudomonas
 Again, this assembly will take too long for now, but it's here for reference anyway.
 
 :cat: :cat:
-Woah déjà vu. :sunglasses:
+Woah, déjà vu!
 
 :warning: do not run the assembly :warning:
 ```bash
@@ -34,7 +34,7 @@ quast.py --output-dir quast ../illumina_only/contigs.fasta contigs.fasta
 cat quast/report.txt
 ```
 
-If you ran the assembly command - outside of the workhop - you may get slightly different results here, as SPAdes uses a random seed.
+If you ran the assembly command - outside of the workshop - you may get slightly different results here, as SPAdes uses a random seed.
 ```
 Assembly                    illumina_only_contigs  hybrid_contigs
 # contigs (>= 0 bp)         612                    265           

--- a/chapter_5/task_7.md
+++ b/chapter_5/task_7.md
@@ -2,7 +2,7 @@
 
 Load your assembled genome - click on "Genome - Load from File..."
 
-Make sure you get the contigs.fasta from the "hybrid" asembly (igv remembers the previous directory which may contain similar files.)
+Make sure you get the contigs.fasta from the "hybrid" assembly (igv remembers the previous directory which may contain similar files.)
 
 Now load your 2 alignment files - click on "Load from File..." and then select pseudo.pacbio.sorted.bam and pseudo.illumina.sorted.bam
 


### PR DESCRIPTION
## Summary
- correct grepping instruction in Task 3
- tweak Task 5 introduction and clean up a stray emoji
- fix `workshop` wording in Tasks 4 and 5
- fix spelling of `assembly` in Task 7

## Testing
- `bash tests/test_chapter_2.sh` *(fails: No such file or directory)*
- `bash tests/test_chapter_3.sh` *(fails: command not found)*
- `bash tests/test_chapter_4.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849923102f48321a441be417fc18e0b