### PR TITLE
Fix paths in Chapter 5 tasks

### DIFF
--- a/chapter_5/task_2.md
+++ b/chapter_5/task_2.md
@@ -5,7 +5,7 @@ It is always important to check and understand the quality of the data you are w
 Change to the directory and run fastqc:
 
 ```bash
-cd ~/workshop_meterials/genomics_adventure/sequencing_data/pseudomonas_gm41
+cd ~/workshop_materials/genomics_adventure/sequencing_data/pseudomonas_gm41
 
 fastqc &
 ```

--- a/chapter_5/task_5.md
+++ b/chapter_5/task_5.md
@@ -3,7 +3,7 @@ Now will execute the same command, but this time include the longer PacBio reads
 
 Return to the pseudomonas directory:
 ```bash
-cd /home/zoo/zool2474/genomics_adventure/pseudomonas
+cd ~/workshop_materials/genomics_adventure/pseudomonas
 ```
 Again, this assembly will take too long for now, but it's here for reference anyway.
 

--- a/chapter_5/task_6.md
+++ b/chapter_5/task_6.md
@@ -3,7 +3,7 @@ Let's realign our original reads back to the assembly and see what we have - ref
 
 Start in the pseudomonas directory, soft link the hybrid assembly and create an index with BWA.
 ```bash
-cd ~/workshop_meterials/genomics_adventure/pseudomonas
+cd ~/workshop_materials/genomics_adventure/pseudomonas
 
 mkdir mapping_to_assembly && cd mapping_to_assembly
 


### PR DESCRIPTION
## Summary
- fix typos in task 2 and task 6 paths
- use project-relative path in task 5

## Testing
- `bash tests/test_chapter_2.sh` *(fails: command not found)*
- `bash tests/test_chapter_3.sh` *(fails: command not found)*
- `bash tests/test_chapter_4.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499b06a8988321b51970b2f98a3843