### PR TITLE
Fix typos in chapter tasks

### DIFF
--- a/chapter_4/task_4.md
+++ b/chapter_4/task_4.md
@@ -15,7 +15,7 @@ Here's one to get you started... Zoom in on "NODE_1..." until you can see the re
 
 What do the colours of the reads mean? Can you guess before you read the [manual](https://igv.org/doc/desktop/#UserGuide/tracks/alignments/paired_end_alignments/#insert-size) 🔍?
 
-So, at the start of the contig we have a lot of reads that map to one contig but their read-pair maps to another contig. This is suggestive of repetetive regions, and if an assembler cannot resolve these repetitive regions with paired-end reads or coverage information, it will generally be unable to assemble any further sequence for that contig. Therefore it is quite common to see contigs which start and end in sequence which is repeated elsewhere.
+So, at the start of the contig we have a lot of reads that map to one contig but their read-pair maps to another contig. This is suggestive of repetitive regions, and if an assembler cannot resolve these repetitive regions with paired-end reads or coverage information, it will generally be unable to assemble any further sequence for that contig. Therefore it is quite common to see contigs which start and end in sequence which is repeated elsewhere.
 
 This part is open-ended and depends on how much you want to explore your genome. There's another task waiting though!
 

--- a/chapter_5/task_4.md
+++ b/chapter_5/task_4.md
@@ -32,7 +32,7 @@ quast.py --output-dir quast contigs.fasta
 cat quast/report.txt
 ```
 
-If you ran the assembly command - outside of the workhop - you may get slightly different results here, as SPAdes uses a random seed.
+If you ran the assembly command - outside of the workshop - you may get slightly different results here, as SPAdes uses a random seed.
 ```
 Assembly                    contigs
 # contigs (>= 0 bp)         612    

--- a/chapter_5/task_5.md
+++ b/chapter_5/task_5.md
@@ -34,7 +34,7 @@ quast.py --output-dir quast ../illumina_only/contigs.fasta contigs.fasta
 cat quast/report.txt
 ```
 
-If you ran the assembly command - outside of the workhop - you may get slightly different results here, as SPAdes uses a random seed.
+If you ran the assembly command - outside of the workshop - you may get slightly different results here, as SPAdes uses a random seed.
 ```
 Assembly                    illumina_only_contigs  hybrid_contigs
 # contigs (>= 0 bp)         612                    265           


### PR DESCRIPTION
## Summary
- fix 'workhop' typos in chapter 5 tasks
- fix 'repetetive' typo in chapter 4

## Testing
- `bash tests/test_chapter_4.sh` *(fails: command not found)*
- `bash tests/test_chapter_3.sh` *(fails: command not found)*
- `bash tests/test_chapter_2.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499b0b2eec8321b35732683611e364