### PR TITLE
Fix typo in chapter 5 task 7

### DIFF
--- a/chapter_5/task_7.md
+++ b/chapter_5/task_7.md
@@ -2,7 +2,7 @@
 
 Load your assembled genome - click on "Genome - Load from File..."
 
-Make sure you get the contigs.fasta from the "hybrid" asembly (igv remembers the previous directory which may contain similar files.)
+Make sure you get the contigs.fasta from the "hybrid" assembly (igv remembers the previous directory which may contain similar files.)
 
 Now load your 2 alignment files - click on "Load from File..." and then select pseudo.pacbio.sorted.bam and pseudo.illumina.sorted.bam
 


### PR DESCRIPTION
## Summary
- correct 'asembly' typo in chapter 5 task 7 documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68499cef28e88321905b32550f6ec56c