### PR TITLE
Fix relative path for plasmid blast check

### DIFF
--- a/chapter_4/task_3.md
+++ b/chapter_4/task_3.md
@@ -93,7 +93,7 @@ If you notice very carefully :wink:, there is one contig which has a size of 468
 
 ```bash
 blastn -subject contigs.fasta \
--query ../../unmapped_assembly/spades_assembly/contigs.fasta \
+-query ../../sequencing_data/ecoli/unmapped_assembly/spades_assembly/contigs.fasta \
 -outfmt 6 -out check_plasmid.blastn
 ```
 

--- a/tests/test_chapter_4.sh
+++ b/tests/test_chapter_4.sh
@@ -23,8 +23,8 @@ samtools index contigs_mapped_sorted.bam
 bwa index contigs.fasta && \ bwa mem -t 2 contigs.fasta \ ../../sequencing_data/ecoli/read_1_val_1.fq.gz \ ../../sequencing_data/ecoli/read_2_val_2.fq.gz \ | samtools sort -O bam -o contigs_mapped_sorted.bam && \ samtools index contigs_mapped_sorted.bam
 samtools flagstat contigs_mapped_sorted.bam
 qualimap bamqc -outdir bamqc -bam contigs_mapped_sorted.bam
-blastn -subject contigs.fasta \
--query ../../unmapped_assembly/spades_assembly/contigs.fasta \
+-blastn -subject contigs.fasta \
+-query ../../sequencing_data/ecoli/unmapped_assembly/spades_assembly/contigs.fasta \
 -outfmt 6 -out check_plasmid.blastn
 
 # task 4


### PR DESCRIPTION
## Summary
- correct the path to the unmapped assembly contigs in task instructions
- update chapter 4 test script accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499d2222b8832180008ace5dd449f4